### PR TITLE
Harmonize the expression marker flag values with what's in the ExprPhenotype table in the WSICore DB on BKI01

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,9 @@ This table contains 62 columns:
       - 570: 16
       - 620: 32
       - 650: 64
-      - 690: 128
-      - 780: 256 <br>
+      - 670: 128
+      - 690: 256
+      - 780: 512 <br>
       
       
 The code also produces a folder named ```*\Results\tmp_inform_data```, which contains .mat files for the images that meet the Image QA criteria, detailed below. These .mat files contain a copy of the ```*_cleaned_phenotype_table.csv``` in an easily accessible MATLAB format.

--- a/massfuncs/getexprmark.m
+++ b/massfuncs/getexprmark.m
@@ -11,8 +11,8 @@
 function o = getexprmark(q,Markers)
 o = q;
 if ~isempty(o.fig)
-    ii = ismember([480;520;540;570;620;650;690;780],Markers.Opals);
-    bins = [2,4,8,16,32,64,128,256];
+    ii = ismember([480;520;540;570;620;650;670;690;780],Markers.Opals);
+    bins = [2,4,8,16,32,64,128,256,512];
     bins(~ii) = [];
     ii = ismember(Markers.all,Markers.expr);
     bins = bins(ii);

--- a/qaqcfuncs/mkphenim.m
+++ b/qaqcfuncs/mkphenim.m
@@ -216,10 +216,10 @@ cols = [];
 %
 % separate the number into binary columns in order of Opals
 %
-% binary numbers = [1,2,4,8,16,32,64,128,256];
-% Opals = [DAPI,480,520,540,570,620,650,690,780];
+% binary numbers = [1,2,4,8,16,32,64,128,256,512];
+% Opals = [DAPI,480,520,540,570,620,650,670,690,780];
 %
-total_opals = [480,520,540,570,620,650,690,780]; % Opals without DAPI
+total_opals = [480,520,540,570,620,650,670,690,780]; % Opals without DAPI
 %
 t2 = tp2.ExprPhenotype;
 phenb = [];


### PR DESCRIPTION
## Overview

This PR fixes an issue we just discovered due to having an expression marker stored in the Opal690 layer for the first time. 

Namely: MaSS was writing out cells expressing that marker with the flag value `128`, but the SQL DBs were expecting them to have flag value `256`, and so they weren't showing up in cellview and the SQL DB loading scripts were throwing an error saying basically that the `CellAll` table had invalid `ExprPhenotype` column entries.

## Explanation

That "flag value `256`" expectation was the result of the `WSICore.dbo.ExprPhenotype` table looking like this:
| Expr | bit | val |
| --- | --- | --- |
| DAPI           |       0 |           1 |
| Opal480     |      1   |         2 |
| Opal520      |     2    |        4 |
| Opal540       |    3     |       8 |
| Opal570        |   4      |      16 |
| Opal620        |   5       |     32 |
| Opal650        |   6       |     64 |
| Opal670        |   7       |     128 |
| Opal690       |    8      |      256 |

while the hardcoded `ismember` `Marker.Opals` list and `bins` var in `getexprmark.m` looked like this:

| Opal | val |
| --- | --- |
| Opal480 |         2 |
| Opal520 |        4 |
| Opal540 |       8 |
| Opal570 |      16 |
| Opal620 |     32 |
| Opal650 |     64 |
| Opal690 |     128 |
| Opal780 |      256 |

Note that the SQL table has an entry for `Opal670` that's not present in the MATLAB code, and the SQL table also does not have an entry for `Opal780` which the MATLAB code does.

## Changes

Alex has edited the SQL table to now have another entry appended for `Opal780`, and the hardcoded matlab values have been edited to match, like:

| Opal/Expr | bit | val |
| --- | --- | --- |
| Opal480 | 1 |        2 |
| Opal520 |  2 |      4 |
| Opal540 |    3 |   8 |
| Opal570 |    4 |  16 |
| Opal620 |   5 |  32 |
| Opal650 |   6 |  64 |
| Opal670 |  7 | 128 |
| Opal690 |   8 |  256 |
| Opal780 |    9 |  512 |

So now even with expression markers in the `Opal690` or `Opal780` layers their `ExprPhenotype` flags will have values recognized by the SQL DBs.

## Out of scope

Obviously having two separate hardcoded definitions of the binary flags is not ideal, and it would be better if both the MATLAB code and the SQL table could be populated from a single source. Knowing that we're about to replace the MaSS code with a new version, however, I've gone with the simple solution of editing the hardcoded values here.

## Validation

I ran the lines surrounding the edits I made here in raw MATLAB pointing to the MergeConfig file for CS51, which is the cohort in which this issue showed up. I didn't write out any actual `*_cleaned_phenotype_tables.csv` output files, but I did confirm that the data structures are all the same before and after the edits, with the sole difference that the flag value at the index corresponding to the marker in the Opal690 layer now ends up as `256` instead of the `128` that it used to be.

I'll be requesting some review to get a second set of eyes on my logic here but if I've read the scripts correctly this *should* be a simple drop in replacement. I know for sure at least that the code will run successfully pointed to an actual MergeConfig file.