### PR TITLE
# Fix getseg altseg CellNum lookup and make parallel pools optional

### DIFF
--- a/CreateImageQAQC.m
+++ b/CreateImageQAQC.m
@@ -101,25 +101,11 @@ if e_code == 1
     return
 end
 %
-% start the parpool if it is not open;
-% attempt to open with local at max cores, if that does not work attempt
-% to open with BG1 profile, otherwise parfor should open with default
+% attempt to start/recover pool; if unavailable continue serially
 %
-if isempty(gcp('nocreate'))
-    try
-        numcores = feature('numcores');
-        if numcores > 6
-            numcores = 6; %#ok<NASGU>
-        end
-        evalc('pool = parpool("local",numcores)');
-    catch EM
-        disp(EM);
-        err_val = 10;
-        e_code = err_handl(wd, sname, logstring, Markers, err_val, 'QA_QC');
-        if e_code == 1
-            return
-        end
-    end
+[use_parallel, ~, par_msg] = startparpool(6, 'CreateImageQAQC');
+if ~isempty(par_msg)
+    mywritetolog(wd, sname, logstring, par_msg, 2, 'QA_QC');
 end
 %
 % make the paths and select the hotspot charts
@@ -151,7 +137,7 @@ mywritetolog(wd, sname, logstring, err_str, 2, 'QA_QC');
 %
 try 
     %
-    err_val = imageloop(wd, sname, logstring, Markers, charts1, doseg);
+    err_val = imageloop(wd, sname, logstring, Markers, charts1, doseg, use_parallel);
     %
 catch
     err_val = 14;
@@ -164,9 +150,12 @@ if e_code == 1
     return
 end
 %
-% close the parallel pool
+% close the parallel pool if one was started
 %
-% delete(pool)
+poolobj = gcp('nocreate');
+if ~isempty(poolobj)
+    delete(poolobj);
+end
 %
 err_str = 'CreateQAQC finished';
 mywritetolog(wd, sname, logstring, err_str, 2, 'QA_QC');

--- a/massfuncs/fileloop.m
+++ b/massfuncs/fileloop.m
@@ -14,31 +14,19 @@ tic
 errors = cell(length(filenms), 1);
 nfiles = 0; %#ok<NASGU>
 %
-% start the parpool if it is not open;
-% attempt to open with local at max cores, if that does not work attempt 
-% to open with BG1 profile, otherwise parfor should open with default
+% attempt to start/recover pool; if unavailable continue serially
 %
-if isempty(gcp('nocreate'))
-    try
-        numcores = feature('numcores');
-        %
-        if numcores > length(filenms) 
-            numcores = ceil(length(filenms)/2);
-        end
-        %
-        if numcores > 12
-            numcores = 12; %#ok<NASGU>
-        end
-        evalc('parpool("local",numcores)');
-    catch
-    end
+max_workers = min(12, max(1, ceil(length(filenms)/2)));
+[use_parallel, ~, par_msg] = startparpool(max_workers, 'MaSS');
+if ~isempty(par_msg)
+    mywritetolog(wd, sname, logstring, par_msg, 2, 'Tables');
 end
 %
 % loop through the mergetbls function for each sample with error catching
 %
 seg_markers = [Markers.seg, Markers.altseg];
 dep_markers = setdiff(Markers.all, seg_markers);
-parfor i1 = 1:length(Markers.nsegs)
+for i1 = 1:length(Markers.nsegs)
     if Markers.nsegs(i1) > 1
         for i2 = 2:Markers.nsegs(i1)
             dep_markers = [dep_markers, strjoin([Markers.all(i1), '_', num2str(i2)], '')];
@@ -63,12 +51,21 @@ end
 figtabledir = [wd, '\Phenotyped\Results\tmp_ForFiguresTables'];
 if length(dir(figtabledir)) < 3
     writecell(header, [wd, '\Phenotyped\Results\cells.csv'],'WriteMode','overwrite')
-    output = cell(length(filenms), 1);  
-    parfor i1 = 1:length(filenms)
-        errors = cell(length(filenms), 1);
-        [output{i1}, errors] = mergeloop(...
-        filenms, sum_filenames, i1, errors, Markers, wd, 1, sname,...
-        logstring, seg_markers, dep_markers);
+    output = cell(length(filenms), 1);
+    if use_parallel
+        parfor i1 = 1:length(filenms)
+            errors = cell(length(filenms), 1);
+            [output{i1}, errors] = mergeloop(...
+            filenms, sum_filenames, i1, errors, Markers, wd, 1, sname,...
+            logstring, seg_markers, dep_markers);
+        end
+    else
+        for i1 = 1:length(filenms)
+            errors = cell(length(filenms), 1);
+            [output{i1}, errors] = mergeloop(...
+            filenms, sum_filenames, i1, errors, Markers, wd, 1, sname,...
+            logstring, seg_markers, dep_markers);
+        end
     end
 end
 for i1 = 1:length(output)
@@ -78,7 +75,9 @@ end
 % close parallel loop
 %
 poolobj = gcp('nocreate');
-delete(poolobj);
+if ~isempty(poolobj)
+    delete(poolobj);
+end
 %
 % get final result measures
 %

--- a/massfuncs/getseg.m
+++ b/massfuncs/getseg.m
@@ -27,10 +27,23 @@ p.fig = [table(CellID),p.fig];
 %
 orows = find(strcmp(p.fig.Phenotype, 'Other'));
 %
+% Load every segmentation owner's binary_seg_maps (layer 4). Polygon
+% lookup uses the map matching the CellNum's parent SegStatus:
+%   coexpression -> endsWith marker (row addcoex keeps)
+%   plain lineage -> that marker
+%   Other -> primary
+%
+[seg_maps, im_size, ok] = load_seg_maps(p, Markers);
+if ~ok
+    p = 18;
+    return
+end
+s = {im_size};
+p.size.T = 2; p.size.B = s{1}(1)-1; p.size.L = 2; p.size.R = s{1}(2)-1;
+%
 % get segmentation outlines for all alternative segmentations
 %
 im3 = cell(length(Markers.altseg));
-tcellids = cell(length(Markers.altseg));
 trows = false(max(CellID),length(Markers.altseg));
 %
 for i1 = 1:length(Markers.altseg)
@@ -47,64 +60,27 @@ for i1 = 1:length(Markers.altseg)
         s_markers = [s_markers, Markers.add(iis)];
     end
     %
-    % get folder and image names for altseg
-    %
-    fdname = [extractBefore(p.fname.folder,Markers.all{1}),...
-        markalt,'\'];
-    iname = [fdname,extractBefore(p.fname.name,...
-        "]_cell_seg"),']_binary_seg_maps.tif'];
-    if isempty(iname)
-        iname = [fdname,extractBefore(p.fname.name,...
-            "]_CELL_SEG"),']_binary_seg_maps.tif'];
-    end
-    %
     % get rows of altseg cells
     %
     trows(:,i1) = ismember(p.fig.Phenotype, s_markers);
+    ids = double(p.fig.CellNum(trows(:,i1),:));
+    phs = p.fig.Phenotype(trows(:,i1));
     %
-    % get inForm cellids of altseg cells
-    %
-    tcellids{i1} = double(p.fig.CellNum(trows(:,i1),:));
-    %
-    % read in the image for segmentation 
-    %
-    im = imread(iname,4);
-    %
-    % convert it to a linear index of labels
-    %
-    im = label2idx(im);
-    im3{i1} = im(1,tcellids{i1});
+    [polys, ok] = lookup_polys_by_kept_marker(ids, phs, Markers, seg_maps);
+    if ~ok
+        p = 18;
+        return
+    end
+    im3{i1} = polys;
 end
 %
-%get filenames for 1ry seg images
-%
-iname = fullfile(p.fname.folder,p.fname.name);
-iname = replace(iname, Markers.all{1}, Markers.seg{1});
-iname = [extractBefore(iname,"]_cell_seg"),']_binary_seg_maps.tif'];
-if isempty(iname)
-    iname = [extractBefore(iname,"]_CELL_SEG"),']_binary_seg_maps.tif'];
-end
-%
-% get cellids of 1ry seg cells
+% primary-seg rows (not claimed by an altseg group)
 %
 trowsall = sum(trows,2) > 0;
 cellids = double(p.fig.CellNum(~trowsall,:));
-%
-% read in image convert to linear index 
-%
-im2 = imread(iname,4);
-im4 = label2idx(im2);
-%
-% get image dimensions
-%
-s = {size(im2)};
-p.size.T = 2; p.size.B = s{1}(1)-1; p.size.L = 2; p.size.R = s{1}(2)-1;
-%
-% Remove non 1ry cells
-%
-try
-    im4 = im4(1,cellids);
-catch EM
+ph_pri = p.fig.Phenotype(~trowsall);
+[im4, ok] = lookup_polys_by_kept_marker(cellids, ph_pri, Markers, seg_maps);
+if ~ok
     p = 18;
     return
 end
@@ -166,5 +142,97 @@ p.fig = vertcat(p.fig,nmr);
 %
 CellID = (1:1:height(p.fig))';
 p.fig.CellID = CellID;
+%
+end
+
+function [seg_maps, im_size, ok] = load_seg_maps(p, Markers)
+%
+ok = true;
+im_size = [];
+seg_maps = containers.Map('KeyType', 'double', 'ValueType', 'any');
+%
+owners = [Markers.seg(:); Markers.altseg(:)];
+for i1 = 1:numel(owners)
+    owner = owners{i1};
+    SS = double(Markers.SegStatus(strcmp(Markers.all, owner)));
+    iname = fullfile(p.fname.folder, p.fname.name);
+    iname = replace(iname, Markers.all{1}, owner);
+    iname2 = [extractBefore(iname, "]_cell_seg"), ']_binary_seg_maps.tif'];
+    if isempty(extractBefore(iname, "]_cell_seg"))
+        iname2 = [extractBefore(iname, "]_CELL_SEG"), ']_binary_seg_maps.tif'];
+    end
+    try
+        im = imread(iname2, 4);
+    catch
+        ok = false;
+        return
+    end
+    if isempty(im_size)
+        im_size = size(im);
+    end
+    seg_maps(SS) = label2idx(im);
+end
+%
+end
+
+function parent_SS = cellnum_parent_segstatus(ph, Markers)
+%
+% SegStatus of the marker whose CellNum is on this row:
+%   coexpression -> endsWith marker (addcoex keeps that row)
+%   plain lineage -> that marker
+%   Other -> primary
+%
+ph = char(string(ph));
+if strcmp(ph, 'Other')
+    parent_SS = double(Markers.SegStatus(strcmp(Markers.all, Markers.seg{1})));
+    return
+end
+if ~isempty(Markers.add) && any(strcmp(string(Markers.add), string(ph)))
+    ew = cellfun(@(x) endsWith(ph, x), Markers.all);
+    matches = Markers.all(ew);
+    if ~isempty(matches)
+        [~, ix] = max(cellfun(@numel, matches));
+        parent_SS = double(Markers.SegStatus(strcmp(Markers.all, matches{ix})));
+        return
+    end
+end
+ii = strcmp(Markers.all, ph);
+if any(ii)
+    parent_SS = double(Markers.SegStatus(ii));
+else
+    parent_SS = double(Markers.SegStatus(strcmp(Markers.all, Markers.seg{1})));
+end
+%
+end
+
+function [polys, ok] = lookup_polys_by_kept_marker(ids, phs, Markers, seg_maps)
+%
+ok = true;
+polys = cell(1, numel(ids));
+if isempty(ids)
+    return
+end
+%
+phs = cellstr(string(phs));
+parent_SS = zeros(numel(ids), 1);
+for i1 = 1:numel(ids)
+    parent_SS(i1) = cellnum_parent_segstatus(phs{i1}, Markers);
+end
+%
+uSS = unique(parent_SS)';
+for SS1 = uSS
+    if ~isKey(seg_maps, SS1)
+        ok = false;
+        return
+    end
+    im = seg_maps(SS1);
+    sel = parent_SS == SS1;
+    these = ids(sel);
+    if any(these < 1 | these > numel(im))
+        ok = false;
+        return
+    end
+    polys(sel) = im(1, these);
+end
 %
 end

--- a/massfuncs/mergeloop.m
+++ b/massfuncs/mergeloop.m
@@ -41,13 +41,19 @@ function [output, errors] = mergeloop(...
         end
         %
     catch EM
-        if contains(EM.message, "file format")
-            e_code = 21;
+        output = '';
+        if ~isempty(EM.stack)
+            err_msg = [fname.name, ' | ', EM.message, ' | ', ...
+                EM.stack(1).name, ' line ', num2str(EM.stack(1).line)];
         else
-            e_code = 14;
+            err_msg = [fname.name, ' | ', EM.message];
         end
+        %
+        % Preserve detailed exception text in logs instead of collapsing to
+        % generic codes 14/21.
+        e_code = 20;
         disp(EM);
-        err_handl(wd, sname, logstring, log_name, e_code, 'Tables', '');
-        errors{i1} = 1;  
+        err_handl(wd, sname, logstring, log_name, e_code, 'Tables', err_msg);
+        errors{i1} = e_code;
     end
     %

--- a/qaqcfuncs/imageloop.m
+++ b/qaqcfuncs/imageloop.m
@@ -6,62 +6,22 @@
 %%%  Loop through all images with proper error handling
 %% --------------------------------------------------------------
 %%
-%% imageloop
-%% --------------------------------------------------------------
-%% Created by: Benjamin Green - Johns Hopkins - 01/03/2018
-%% --------------------------------------------------------------
-%% Description
-%%%  Loop through all images with proper error handling
-%% --------------------------------------------------------------
-%%
-function err_val = imageloop(wd, uc, logstring, Markers, charts, doseg)
+function err_val = imageloop(wd, uc, logstring, Markers, charts, doseg, use_parallel)
 %
 err_val = 0;
 e = cell(length(charts),1);
+if nargin < 7
+    use_parallel = false;
+end
 %
-parfor i2 = 1:length(charts)
-    log_name = extractBefore(charts(i2).name, '_cleaned');
-    disp(charts(i2).name);
-    try 
-        %
-        %open mat lab data structure
-        %
-        err_str = ['CreateQAQC ', log_name, ' started'];
-        mywritetolog(wd, uc, logstring, err_str, 2, 'QA_QC');
-        %
-        [s{i2}, imageid{i2}, mycol{i2}, imc, simage]...
-            =  mkimageid(charts, i2, wd, Markers, doseg); %#ok<PFOUS,PFBNS>
-        s{i2}.fig.CellXPos = round(s{i2}.fig.CellXPos);
-        s{i2}.fig.CellYPos = round(s{i2}.fig.CellYPos);
-        %
-        %make overlayed phenotype map and save the data stucture for later
-        %
-        [s{i2},ima, imas] = mkphenim(s{i2}, Markers, mycol{i2},...
-            imageid{i2}, imc, simage, doseg);
-        %
-        %make moscaics for expression and lineage markers
-        %
-        mkindvphenim(...
-            s{i2}, mycol{i2}, imageid{i2},...
-            imc, simage, Markers, ima, imas);
-        mkexprim(...
-            mycol{i2}, imageid{i2}, imc, Markers, ima, imas, wd);
-        %
-        err_str = ['CreateQAQC ', log_name, ' finished'];
-        mywritetolog(wd, uc, logstring, err_str, 2, 'QA_QC');
-        e{i2} = 0;
-    catch E
-        if contains(E.message, "expression segmentation")
-            e{i2} = 1;
-            err_str = ['ERROR: ', E.message, ' does not match primary segmentation'];
-            mywritetolog(wd, uc, logstring, err_str, 2, 'QA_QC');
-        else
-            e{i2} = 1;
-            err_str = ['ERROR: CreateQAQC ', log_name, ' failed'];
-            mywritetolog(wd, uc, logstring, err_str, 2, 'QA_QC');
-        end
+if use_parallel
+    parfor i2 = 1:length(charts)
+        e{i2} = process_qaqc_chart(wd, uc, logstring, Markers, charts, i2, doseg);
     end
-    %
+else
+    for i2 = 1:length(charts)
+        e{i2} = process_qaqc_chart(wd, uc, logstring, Markers, charts, i2, doseg);
+    end
 end
 %
 % make pie chart figure with heatmap
@@ -100,4 +60,43 @@ else
     end
 end
 %
+end
+
+function e = process_qaqc_chart(wd, uc, logstring, Markers, charts, i2, doseg)
+log_name = extractBefore(charts(i2).name, '_cleaned');
+disp(charts(i2).name);
+try
+    %
+    %open mat lab data structure
+    %
+    err_str = ['CreateQAQC ', log_name, ' started'];
+    mywritetolog(wd, uc, logstring, err_str, 2, 'QA_QC');
+    %
+    [s, imageid, mycol, imc, simage] = mkimageid(charts, i2, wd, Markers, doseg);
+    s.fig.CellXPos = round(s.fig.CellXPos);
+    s.fig.CellYPos = round(s.fig.CellYPos);
+    %
+    %make overlayed phenotype map and save the data stucture for later
+    %
+    [s, ima, imas] = mkphenim(s, Markers, mycol, imageid, imc, simage, doseg);
+    %
+    %make moscaics for expression and lineage markers
+    %
+    mkindvphenim(s, mycol, imageid, imc, simage, Markers, ima, imas);
+    mkexprim(mycol, imageid, imc, Markers, ima, imas, wd);
+    %
+    err_str = ['CreateQAQC ', log_name, ' finished'];
+    mywritetolog(wd, uc, logstring, err_str, 2, 'QA_QC');
+    e = 0;
+catch E
+    if contains(E.message, "expression segmentation")
+        e = 1;
+        err_str = ['ERROR: ', E.message, ' does not match primary segmentation'];
+        mywritetolog(wd, uc, logstring, err_str, 2, 'QA_QC');
+    else
+        e = 1;
+        err_str = ['ERROR: CreateQAQC ', log_name, ' failed'];
+        mywritetolog(wd, uc, logstring, err_str, 2, 'QA_QC');
+    end
+end
 end

--- a/shared/err_handl_tables.m
+++ b/shared/err_handl_tables.m
@@ -104,7 +104,8 @@ if err_val ~= 0
             err_str = ['ERROR: Cell segmentation file missing'];
             e_code = 1;
         case 20
-            err_str = strjoin(['ERROR:' err_msg]);
+            % err_msg may be char, string, or cellstr depending on caller
+            err_str = char(strjoin(["ERROR:", string(err_msg)], " "));
             e_code = 1;
         case 21
             err_str = ['ERROR: Check for empty or corrupt inform output files'];

--- a/shared/startparpool.m
+++ b/shared/startparpool.m
@@ -1,0 +1,62 @@
+function [use_parallel, pool, status_msg] = startparpool(max_workers, task_label)
+%
+% Attempt to start/recover a local parallel pool.
+% Falls back to serial execution if pool validation/start fails.
+%
+use_parallel = false;
+pool = [];
+status_msg = '';
+%
+if nargin < 1 || isempty(max_workers)
+    max_workers = inf;
+end
+if nargin < 2
+    task_label = 'task';
+end
+%
+try
+    pool = gcp('nocreate');
+catch EM
+    status_msg = ['Could not query existing parallel pool for ', task_label, ...
+        '. Running serially. ', EM.message];
+    return
+end
+%
+if isempty(pool)
+    try
+        numcores = feature('numcores');
+        requested_workers = min(numcores, max_workers);
+        if isempty(requested_workers) || requested_workers < 1
+            requested_workers = 1;
+        end
+        %
+        pool = parpool('local', requested_workers);
+    catch
+        %
+        % Self-heal attempt for stale worker state, then retry once.
+        %
+        try
+            pool = gcp('nocreate');
+            if ~isempty(pool)
+                delete(pool);
+            end
+            pool = parpool('local');
+        catch
+            status_msg = ['Parallel pool unavailable for ', task_label, ...
+                '. Running serially.'];
+            pool = [];
+            use_parallel = false;
+            return
+        end
+    end
+end
+%
+use_parallel = ~isempty(pool);
+if use_parallel
+    status_msg = ['Parallel pool ready for ', task_label, '.'];
+else
+    status_msg = ['Parallel pool unavailable for ', task_label, ...
+        '. Running serially.'];
+end
+%
+end


### PR DESCRIPTION
## Overview

This PR fixes `getseg` so membrane polygons are looked up on the segmentation map that owns each row’s `CellNum` (including cross-seg coexpression), preventing  crashes and incorrect Other cleanup. It also makes MaSS / CreateImageQAQC fall back to serial execution when a parallel pool cannot start, and improves merge-loop error reporting.

## Changes

- **`getseg` map ownership fix** in `massfuncs/getseg.m`:
    - Load all seg-owner `binary_seg_maps` keyed by `SegStatus`
    - Resolve parent SegStatus per row: coex → endsWith marker; lineage → that marker; Other → primary
    - Index polygons from the matching map instead of the altseg group map
- **Optional parallelism** via new `shared/startparpool.m`:
    - Try/recover local pool; on failure continue serially and log a message
    - Wired into `massfuncs/fileloop.m`, `CreateImageQAQC.m`, and `qaqcfuncs/imageloop.m`
- **Clearer merge failures**:
    - `mergeloop` catch path always sets `output`, logs detailed exception text as code 20 (instead of collapsing to 14/21)
    - Resolves Dot Indexing error